### PR TITLE
Update call to `dandi_download`

### DIFF
--- a/NWBWidget-demo.ipynb
+++ b/NWBWidget-demo.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dandi_download([url], os.getcwd(), existing=\"skip\")"
+    "dandi_download([url], os.getcwd(), existing=\"skip\", develop_debug=False)"
    ]
   },
   {
@@ -119,6 +119,13 @@
    "source": [
     "nwb2widget(nwb)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds required argument `develop_debug` (does that really need to be a required argument?)