### PR TITLE
added sex to the subect description in the nwb file

### DIFF
--- a/dandi/DANDI User Guide, Part I.ipynb
+++ b/dandi/DANDI User Guide, Part I.ipynb
@@ -59,6 +59,7 @@
     "        subject_id=subject_id,\n",
     "        species='Mus musculus',\n",
     "        age='P90D',\n",
+    "        sex='F',\n",
     "    )\n",
     "\n",
     "    device = nwbfile.create_device(name='trodes_rig123')\n",


### PR DESCRIPTION
The nwb file being created as part of the user guide/tutorial had to pass validation before uploading, which failed without the required `sex` field. 
Added the field in the `create_nwbfile` function