### PR TITLE
Add dependabot.yml to explicitly disable pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # do not provide pip upgrades -- notebooks might need specific versions
+  - package-ecosystem: "pip"
+    directory: "/"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Closes #54  and all those PRs:  Closes #48 #49 #50 #51 #52 #53

Not sure if this config would be in effect, but we wouldn't know until try

I would prefer be explicit via this config since adds a note instead of just disabling dependabot in the configuration -- we might would want it for some other updates