### PR TITLE
Update swagger URLs

### DIFF
--- a/dandi/DANDI User Guide, Part II.ipynb
+++ b/dandi/DANDI User Guide, Part II.ipynb
@@ -458,7 +458,7 @@
     "\n",
     "All code of the DANDI API server is available openly from https://github.com/dandi/dandi-api/ . A number of convenient interfaces are available to help you learn about what features it provides, and how to interact with the server.\n",
     "\n",
-    "Both production and sandbox servers have a [Swagger](https://swagger.io/) interface, which you can reach by going to https://api.dandiarchive.org/swagger/ for production (and https://api.sandbox.dandiarchive.org/swagger/ for sandbox, which is where your test datasets are):\n",
+    "Both production and sandbox servers have a [Swagger](https://swagger.io/) interface, which you can reach by going to https://api.dandiarchive.org/api/docs/swagger/ for production (and https://api.sandbox.dandiarchive.org/api/docs/swagger/ for sandbox, which is where your test datasets are):\n",
     "\n",
     "![image.png](attachment:image.png)\n",
     "\n",


### PR DESCRIPTION
These URLs now live under `/api/docs/`. dandi-archive PR that changed them is here - https://github.com/dandi/dandi-archive/pull/2327

I noticed this while reviewing #113. The old URLs do technically still work, but they just redirect to the new URLs.