### PR TITLE
Redesign index page with DANDI brand styling

### DIFF
--- a/.github/templates/index.html
+++ b/.github/templates/index.html
@@ -3,101 +3,413 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DANDI Datasets</title>
+    <title>DANDI Example Notebooks</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --navy: #00436D;
+            --navy-dark: #002f4d;
+            --navy-soft: #2a6a94;
+            --rose: #D3868D;
+            --rose-light: #F0A5AC;
+            --rose-dark: #A05A60;
+
+            --bg: #ffffff;
+            --bg-soft: #f5f7fa;
+            --bg-band: #fbfcfd;
+            --ink: #1a2733;
+            --ink-soft: #546070;
+            --ink-faint: #8a96a5;
+            --rule: #e3e8ee;
+            --rule-strong: #c8d2de;
+        }
+
+        * { box-sizing: border-box; }
+        html { scroll-behavior: smooth; }
+
         body {
-            font-family: 'Arial', sans-serif;
-            line-height: 1.6;
             margin: 0;
-            padding: 20px;
+            background: var(--bg);
+            color: var(--ink);
+            font-family: 'Roboto', -apple-system, sans-serif;
+            font-size: 16px;
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+            text-rendering: optimizeLegibility;
         }
+
         .container {
-            max-width: 1200px;
+            max-width: 1160px;
             margin: 0 auto;
+            padding: 0 32px;
         }
-        h1 {
-            text-align: center;
-            margin-bottom: 30px;
+
+        /* Header */
+        header.site {
+            background: linear-gradient(135deg, var(--navy) 0%, var(--navy-dark) 100%);
+            color: #fff;
+            padding: 72px 0 72px;
+            position: relative;
+            overflow: hidden;
+            border-bottom: 4px solid var(--rose);
         }
-        .dandiset {
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            margin-bottom: 30px;
-            padding: 20px;
-            transition: box-shadow 0.3s ease;
+        header.site::before {
+            content: '';
+            position: absolute;
+            top: -120px;
+            right: -80px;
+            width: 360px;
+            height: 360px;
+            background: radial-gradient(circle, var(--rose) 0%, transparent 70%);
+            opacity: 0.18;
+            pointer-events: none;
         }
-        .dandiset:hover {
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+        header.site::after {
+            content: '';
+            position: absolute;
+            bottom: -100px;
+            left: 10%;
+            width: 260px;
+            height: 260px;
+            background: radial-gradient(circle, var(--rose-light) 0%, transparent 70%);
+            opacity: 0.12;
+            pointer-events: none;
         }
-        .dandiset h2 {
-            margin-top: 0;
-            margin-bottom: 15px;
+        header.site .container { position: relative; z-index: 1; }
+        .eyebrow {
+            font-family: 'Roboto Mono', monospace;
+            font-size: 12px;
+            font-weight: 500;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--rose-light);
+            margin-bottom: 18px;
         }
-        .dandiset p {
-            margin-bottom: 10px;
+        h1.site-title {
+            font-family: 'Roboto Slab', Georgia, serif;
+            font-weight: 600;
+            font-size: clamp(40px, 6vw, 64px);
+            line-height: 1.05;
+            letter-spacing: -0.02em;
+            margin: 0 0 22px;
+            color: #fff;
         }
-        .dandiset a {
+        .site-lede {
+            font-family: 'Roboto', sans-serif;
+            font-weight: 300;
+            font-size: 19px;
+            line-height: 1.55;
+            color: rgba(255, 255, 255, 0.82);
+            max-width: 62ch;
+            margin: 0;
+        }
+
+        /* Main layout */
+        .main-wrap { padding: 64px 0 0; }
+
+        .layout {
+            display: grid;
+            grid-template-columns: 340px 1fr;
+            gap: 64px;
+            align-items: start;
+        }
+
+        aside.toc {
+            position: sticky;
+            top: 32px;
+            max-height: calc(100vh - 64px);
+            overflow-y: auto;
+            padding-right: 8px;
+        }
+        .toc-heading {
+            font-family: 'Roboto Mono', monospace;
+            font-size: 11px;
+            font-weight: 500;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--navy);
+            margin: 0 0 16px;
+            padding-bottom: 14px;
+            border-bottom: 2px solid var(--navy);
+        }
+        .toc ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .toc li { margin: 0; }
+        .toc a {
+            display: block;
+            color: var(--ink-soft);
             text-decoration: none;
-            font-weight: bold;
+            font-size: 13.5px;
+            line-height: 1.45;
+            padding: 10px 0 10px 14px;
+            border-left: 2px solid var(--rule);
+            transition: color 0.2s ease, border-color 0.2s ease, padding-left 0.2s ease, background 0.2s ease;
         }
-        .dandiset a:hover {
-            text-decoration: underline;
+        .toc a:hover {
+            color: var(--navy);
+            border-left-color: var(--rose);
+            padding-left: 18px;
+            background: var(--bg-soft);
         }
+        .toc a .toc-id {
+            font-family: 'Roboto Mono', monospace;
+            font-size: 10.5px;
+            font-weight: 500;
+            letter-spacing: 0.04em;
+            color: var(--rose-dark);
+            display: block;
+            margin-bottom: 3px;
+        }
+
+        /* Datasets */
+        main.datasets { min-width: 0; }
+
+        .dandiset {
+            padding: 44px 0 52px;
+            border-bottom: 1px solid var(--rule);
+        }
+        .dandiset:first-child { padding-top: 4px; }
+        .dandiset:last-child { border-bottom: none; }
+
+        .dandiset-id {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 11.5px;
+            font-weight: 500;
+            letter-spacing: 0.08em;
+            color: var(--navy);
+            background: rgba(0, 67, 109, 0.07);
+            padding: 5px 10px;
+            border-radius: 3px;
+            margin-bottom: 16px;
+            text-transform: uppercase;
+        }
+        .dandiset-id::before {
+            content: '';
+            width: 6px;
+            height: 6px;
+            background: var(--rose);
+            border-radius: 50%;
+        }
+
+        .dandiset h2 {
+            font-family: 'Roboto Slab', Georgia, serif;
+            font-weight: 500;
+            font-size: 28px;
+            line-height: 1.25;
+            letter-spacing: -0.01em;
+            margin: 0 0 18px;
+            color: var(--ink);
+        }
+
+        .dandiset p.description {
+            color: var(--ink-soft);
+            font-size: 15.5px;
+            line-height: 1.65;
+            margin: 0 0 24px;
+            max-width: 70ch;
+            font-weight: 400;
+        }
+
+        .archive-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-family: 'Roboto', sans-serif;
+            font-size: 13px;
+            font-weight: 500;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: #fff;
+            background: var(--navy);
+            text-decoration: none;
+            padding: 10px 18px;
+            border-radius: 3px;
+            transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
+        }
+        .archive-link::after {
+            content: '→';
+            transition: transform 0.2s;
+            font-size: 14px;
+        }
+        .archive-link:hover {
+            background: var(--navy-dark);
+            box-shadow: 0 4px 12px rgba(0, 67, 109, 0.2);
+        }
+        .archive-link:hover::after { transform: translateX(3px); }
+
         .notebooks {
-            margin-top: 15px;
+            margin-top: 32px;
+            padding: 24px 28px;
+            background: var(--bg-band);
+            border: 1px solid var(--rule);
+            border-left: 3px solid var(--rose);
+            border-radius: 3px;
         }
-        .notebooks h3 {
-            font-size: 1.1em;
-            margin-bottom: 10px;
+        .notebooks-heading {
+            font-family: 'Roboto Mono', monospace;
+            font-size: 11px;
+            font-weight: 500;
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+            color: var(--navy);
+            margin: 0 0 14px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .notebooks-heading::after {
+            content: '';
+            flex: 1;
+            height: 1px;
+            background: var(--rule);
         }
         .notebooks ul {
-            list-style-type: disc;
-            padding-left: 20px;
+            list-style: none;
+            padding: 0;
+            margin: 0;
         }
         .notebooks li {
-            margin-bottom: 5px;
+            padding: 8px 0;
+            border-top: 1px solid var(--rule);
         }
-        @media (max-width: 768px) {
-            body {
-                padding: 10px;
+        .notebooks li:first-child {
+            border-top: none;
+            padding-top: 2px;
+        }
+        .notebooks li:last-child { padding-bottom: 2px; }
+        .notebooks a {
+            color: var(--ink);
+            text-decoration: none;
+            font-size: 13.5px;
+            font-family: 'Roboto Mono', monospace;
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            transition: color 0.2s;
+            word-break: break-all;
+        }
+        .notebooks a::before {
+            content: '';
+            width: 14px;
+            height: 2px;
+            background: var(--rose);
+            flex-shrink: 0;
+            transition: width 0.2s, background 0.2s;
+        }
+        .notebooks a:hover { color: var(--navy); }
+        .notebooks a:hover::before {
+            width: 22px;
+            background: var(--navy);
+        }
+
+        /* Footer */
+        footer.site {
+            padding: 56px 0 48px;
+            margin-top: 64px;
+            background: var(--bg-soft);
+            border-top: 1px solid var(--rule);
+            font-family: 'Roboto', sans-serif;
+            font-size: 13px;
+            color: var(--ink-soft);
+            text-align: center;
+        }
+        footer.site .brand {
+            font-family: 'Roboto Slab', serif;
+            font-weight: 600;
+            color: var(--navy);
+            letter-spacing: -0.01em;
+            font-size: 15px;
+            margin-bottom: 6px;
+        }
+        footer.site a {
+            color: var(--navy);
+            text-decoration: none;
+            font-weight: 500;
+        }
+        footer.site a:hover { color: var(--rose-dark); text-decoration: underline; }
+
+        @media (max-width: 900px) {
+            .layout {
+                grid-template-columns: 1fr;
+                gap: 40px;
             }
-            .dandiset {
-                padding: 15px;
+            aside.toc {
+                position: static;
+                max-height: none;
+                padding: 0 0 28px;
+                border-bottom: 1px solid var(--rule);
             }
+            header.site { padding: 56px 0 56px; }
+            .main-wrap { padding: 44px 0 0; }
+            .container { padding: 0 22px; }
+            .dandiset h2 { font-size: 23px; }
+            .dandiset { padding: 36px 0 40px; }
         }
     </style>
 </head>
 <body>
-<div class="container">
-    <h1>DANDI Datasets</h1>
-
-    <div class="toc">
-        <h2>Table of Contents</h2>
-        <ul>
-            {% for dandiset in dandisets %}
-            <li><a href="#dandiset-{{ dandiset.id }}">{{ dandiset.id }} - {{ dandiset.metadata.name }}</a></li>
-            {% endfor %}
-        </ul>
-    </div>
-
-    {% for dandiset in dandisets %}
-    <div id="dandiset-{{ dandiset.id }}" class="dandiset">
-        <h2>{{ dandiset.metadata.name }}</h2>
-        <p><strong>ID:</strong> {{ dandiset.id }}</p>
-        <p><strong>Description:</strong> {{ dandiset.metadata.description }}</p>
-        <p><a href="https://dandiarchive.org/dandiset/{{ dandiset.id }}" target="_blank">View on DANDI Archive</a></p>
-        {% if dandiset.notebooks %}
-        <div class="notebooks">
-            <h3>Notebooks:</h3>
-            <ul>
-                {% for notebook in dandiset.notebooks %}
-                <li><a href="https://github.com/dandi/example-notebooks/blob/master/{{ dandiset.id }}/{{ notebook }}" target="_blank">{{ notebook }}</a></li>
-                {% endfor %}
-            </ul>
+    <header class="site">
+        <div class="container">
+            <div class="eyebrow">Example Notebooks Index</div>
+            <h1 class="site-title">DANDI Datasets</h1>
+            <p class="site-lede">A curated index of example Jupyter notebooks for datasets hosted on the DANDI Archive — reference workflows for exploring open neurophysiology data across labs, species, and modalities.</p>
         </div>
-        {% endif %}
+    </header>
+
+    <div class="main-wrap">
+        <div class="container">
+            <div class="layout">
+                <aside class="toc">
+                    <h2 class="toc-heading">Contents</h2>
+                    <ul>
+                        {% for dandiset in dandisets %}
+                        <li>
+                            <a href="#dandiset-{{ dandiset.id }}">
+                                <span class="toc-id">DANDI:{{ dandiset.id }}</span>
+                                {{ dandiset.metadata.name }}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </aside>
+
+                <main class="datasets">
+                    {% for dandiset in dandisets %}
+                    <article id="dandiset-{{ dandiset.id }}" class="dandiset">
+                        <div class="dandiset-id">DANDI:{{ dandiset.id }}</div>
+                        <h2>{{ dandiset.metadata.name }}</h2>
+                        <p class="description">{{ dandiset.metadata.description }}</p>
+                        <a class="archive-link" href="https://dandiarchive.org/dandiset/{{ dandiset.id }}" target="_blank" rel="noopener">View on DANDI Archive</a>
+                        {% if dandiset.notebooks %}
+                        <div class="notebooks">
+                            <h3 class="notebooks-heading">Notebooks</h3>
+                            <ul>
+                                {% for notebook in dandiset.notebooks %}
+                                <li><a href="https://github.com/dandi/example-notebooks/blob/master/{{ dandiset.id }}/{{ notebook }}" target="_blank" rel="noopener">{{ notebook }}</a></li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                        {% endif %}
+                    </article>
+                    {% endfor %}
+                </main>
+            </div>
+        </div>
     </div>
-    {% endfor %}
-</div>
+
+    <footer class="site">
+        <div class="container">
+            <div class="brand">DANDI Example Notebooks</div>
+            <a href="https://github.com/dandi/example-notebooks" target="_blank" rel="noopener">github.com/dandi/example-notebooks</a>
+        </div>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Refresh the generated `index.html` with DANDI's brand palette: deep navy (`#00436D`) header, rose (`#D3868D`) accent, Roboto / Roboto Slab / Roboto Mono typography.
- Add a sticky sidebar table of contents (340px wide) and a clearer dataset card layout with a navy CTA button and a rose-accented notebooks panel.
- Responsive collapse under 900px (sidebar stacks above the list).

Only `.github/templates/index.html` is changed; the generator script is untouched.

## Test plan
- [x] Rendered locally via `python .github/scripts/collect_and_render.py` against the real DANDI API and reviewed `output/index.html` in a browser (all 27 dandisets).
- [ ] Verify the GitHub Action that publishes the index picks up the new template on next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)