### PR TITLE
Fix master index workflow: bump dandi and Python

### DIFF
--- a/.github/workflows/index_workflow.yml
+++ b/.github/workflows/index_workflow.yml
@@ -8,21 +8,21 @@ jobs:
   collect-and-render:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    
+    - uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    
+        python-version: '3.11'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install requests jinja2 dandi
-    
+        pip install requests jinja2 'dandi>=0.74.0'
+
     - name: Run metadata collector and renderer
       run: python .github/scripts/collect_and_render.py
-    
+
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
## Summary
- The DANDI server now requires client `>=0.74.0`, but pip on Python 3.9 resolves to `dandi==0.73.2`, so the master publish step has started failing with `CliVersionTooOldError`. See [run 24435366796](https://github.com/dandi/example-notebooks/actions/runs/24435366796/job/71388349354).
- Bump `actions/setup-python` to Python 3.11, pin `dandi>=0.74.0`.
- While here, upgrade `actions/checkout@v2` → `@v4` and `actions/setup-python@v2` → `@v5` to clear the Node 20 deprecation warnings.

## Test plan
- [ ] Merge, then observe the next master push triggers `DANDI Metadata Collector` and completes the deploy step successfully.
- [ ] Confirm the published index at https://dandi.github.io/example-notebooks/ is refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)