### PR TITLE
Fix Create_manifest: add missing 'import pandas as pd'

### DIFF
--- a/000039/AllenInstitute/Create_manifest.ipynb
+++ b/000039/AllenInstitute/Create_manifest.ipynb
@@ -36,6 +36,7 @@
    },
    "outputs": [],
    "source": [
+    "import pandas as pd\n",
     "from dandi.dandiapi import DandiAPIClient"
    ]
   },


### PR DESCRIPTION
The notebook uses `pd.DataFrame()` (cell with `manifest = pd.DataFrame(columns=...)`) and `pd.pivot_table()` but never imports pandas, so it raises `NameError: name 'pd' is not defined` at runtime.

One-line fix: add `import pandas as pd` to the existing imports cell.

Caught by the headless test sweep of #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)