### PR TITLE
Fix NWBWidget-demo: update stale 000054 asset path

### DIFF
--- a/demos/NWBWidget-demo.ipynb
+++ b/demos/NWBWidget-demo.ipynb
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "# calcium imaging, Giocomo Lab (30 GB)\n",
-    "dandiset_id, filepath = \"000054\", \"sub-F2/sub-F2_ses-20190407T210000_behavior+ophys.nwb\"\n",
+    "dandiset_id, filepath = \"000054\", \"sub-F2/sub-F2_ses-training-day1_behavior+ophys.nwb\"\n",
     "\n",
     "# neuropixel, Giocomo Lab (46 GB)\n",
     "#dandiset_id, filepath = \"000053\", \"sub-npI1/sub-npI1_ses-20190415_behavior+ecephys.nwb\"\n",

--- a/demos/NWBWidget-demo.ipynb
+++ b/demos/NWBWidget-demo.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# calcium imaging, Giocomo Lab (30 GB)\n",
+    "# calcium imaging, Giocomo Lab (1.4 GB)\n",
     "dandiset_id, filepath = \"000054\", \"sub-F2/sub-F2_ses-training-day1_behavior+ophys.nwb\"\n",
     "\n",
     "# neuropixel, Giocomo Lab (46 GB)\n",


### PR DESCRIPTION
The default asset path `sub-F2/sub-F2_ses-20190407T210000_behavior+ophys.nwb` no longer exists in dandiset 000054 — the dandiset was reorganized to use a `ses-training-day{N}` / `ses-testing-day{N}` naming scheme. The notebook errors out at the first `_search_assets` call with `ValueError: path … not found in dandiset 000054.`

Updated to `sub-F2/sub-F2_ses-training-day1_behavior+ophys.nwb` (1.4 GB), a small representative file under the same subject.

Caught by the headless test sweep of #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)