### PR TITLE
Fix DANDI User Guide Part I: uncomment a working default dandiset

### DIFF
--- a/dandi/DANDI User Guide, Part I.ipynb
+++ b/dandi/DANDI User Guide, Part I.ipynb
@@ -305,7 +305,7 @@
     "#dandiset_id, filepath = \"000053\", \"sub-npI1/sub-npI1_ses-20190415_behavior+ecephys.nwb\"\n",
     "\n",
     "# neuropixel, Allen Intitute\n",
-    "#dandiset_id, filepath = \"000022\", \"sub-744912845/sub-744912845_ses-766640955.nwb\"\n",
+    "dandiset_id, filepath = \"000022\", \"sub-744912845/sub-744912845_ses-766640955.nwb\"\n",
     "\n",
     "# ecephys, Buzsaki Lab (15.2 GB)\n",
     "#dandiset_id, filepath = \"000003\", \"sub-YutaMouse41/sub-YutaMouse41_ses-YutaMouse41-150831_behavior+ecephys.nwb\""


### PR DESCRIPTION
The example-selector cell had **all four** candidate `(dandiset_id, filepath)` pairs commented out, so the next cell hit `NameError: name 'dandiset_id' is not defined` on a run-all-cells. The original intent seemed to be that a user manually edits the cell, but a notebook should still execute end-to-end out of the box (and the next cells in the guide assume `dandiset_id`/`filepath` are set).

Verified current asset existence for all four candidates against the live DANDI API:

| Dandiset | Path | Status |
|---|---|---|
| 000054 | `sub-F2/sub-F2_ses-20190407T210000_behavior+ophys.nwb` | gone |
| 000053 | `sub-npI1/sub-npI1_ses-20190415_behavior+ecephys.nwb` | gone |
| 000022 | `sub-744912845/sub-744912845_ses-766640955.nwb` | **exists** ✓ |
| 000003 | `sub-YutaMouse41/sub-YutaMouse41_ses-YutaMouse41-150831_behavior+ecephys.nwb` | gone |

Uncommented the 000022 line — the only one that currently resolves. Left the other three commented untouched (they'd need fresh paths from the current dandiset state; out of scope here).

Caught by the headless test sweep of #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)