### PR TITLE
codespell: ignore 'makin' (author surname)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,5 @@ skip = .git,*.pdf,*.svg
 # all images and other binaries embedded in .ipynb jsons
 ignore-regex = "image/png": ".*|^ *".*data:\S+;base64.*
 # nd - people just like it
-ignore-words-list = nd,trough,mater,mebrains
+# makin - surname (Joseph G. Makin, cited in 000129/MathisLab CEBRA notebook)
+ignore-words-list = nd,trough,mater,mebrains,makin


### PR DESCRIPTION
Fixes the [Codespell run on PR #100](https://github.com/dandi/example-notebooks/actions/runs/25768064752/job/75684996267) (and any future PR — codespell runs on every push/PR).

## What was failing

Codespell flagged three lines in `000129/MathisLab/Schneider2023_CEBRA/230905_NeuroDataReHack_2023_CEBRA.ipynb`:

```
./000129/MathisLab/Schneider2023_CEBRA/230905_NeuroDataReHack_2023_CEBRA.ipynb:132: Makin ==> Making, Main
./000129/MathisLab/Schneider2023_CEBRA/230905_NeuroDataReHack_2023_CEBRA.ipynb:141: Makin ==> Making, Main
./000129/MathisLab/Schneider2023_CEBRA/230905_NeuroDataReHack_2023_CEBRA.ipynb:143: Makin ==> Making, Main
```

All three are references to **author Joseph G. Makin** in academic citations:

- "*Makin et al., 2018*" — describing the dataset's origin paper
- "*[1] O'Doherty, Joseph E., Cardoso, Mariana M. B., Makin, Joseph G., & Sabes, Philip N.*" — full author list
- "*[2] Makin, J.G., O'Doherty, J.E., …*" — second citation

## Fix

Added `makin` to `ignore-words-list` in `.codespellrc`, with an inline comment explaining why. The author's name stays intact.

Verified locally that codespell now passes on the CEBRA notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)