### PR TITLE
Replace np.NaN with np.nan for numpy 2.x compatibility

### DIFF
--- a/000559/dattalab/markowitz_gillis_nature_2023/reproduce_figure1d.ipynb
+++ b/000559/dattalab/markowitz_gillis_nature_2023/reproduce_figure1d.ipynb
@@ -155,6 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
+   "id": "ffdf8a0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,6 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
+   "id": "d073aed9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,6 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
+   "id": "6b68cdef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +283,7 @@
     "    acc = acc[moseq_extract_timemask].to_numpy() * 30\n",
     "    vel = velocity[moseq_extract_timemask].to_numpy() * 30\n",
     "    vel_angle = angle.interpolate(limit_direction=\"both\").diff(2) * 30 * -1\n",
-    "    vel_angle[np.abs(vel_angle) > 100] = np.NaN # remove artifacts\n",
+    "    vel_angle[np.abs(vel_angle) > 100] = np.nan # remove artifacts\n",
     "    vel_angle = vel_angle.interpolate(limit_direction=\"both\")\n",
     "    vel_angle = vel_angle[moseq_extract_timemask].to_numpy()\n",
     "    syllables = syllables.iloc[start : start + n_frames].to_numpy()\n",
@@ -360,6 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
+   "id": "eee818db",
    "metadata": {},
    "outputs": [
     {
@@ -380,6 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5f7805e5",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
NumPy 2.0 removed the deprecated capitalized alias `np.NaN` in favor of `np.nan` (the canonical lowercase form, which has always existed). Searching the repo:

- **`np.NaN`**: 1 notebook — `000559/dattalab/markowitz_gillis_nature_2023/reproduce_figure1d.ipynb` (one usage)
- **`np.NAN`, `np.Inf`, `np.product`, `np.cumproduct`, `np.sometrue`, `np.alltrue`, `np.float_`, `np.complex_`, `np.unicode_`, `np.cast`**: none in `.ipynb` files outside the (already-excluded) DataJoint subdirs.

This PR converts the single occurrence:

```diff
- vel_angle[np.abs(vel_angle) > 100] = np.NaN  # remove artifacts
+ vel_angle[np.abs(vel_angle) > 100] = np.nan  # remove artifacts
```

That was the only thing keeping this notebook pinned to `numpy<2` in #149's lockfile (the resolver dropped numpy from the Colab constraint set for this one because `np.NaN` is gone in numpy 2.x). After this lands, the next regen on #149 will pick up `numpy==2.0.2` for this notebook, matching Colab — and Colab users won't need to restart the runtime on install.

## Notebooks NOT touched (and why)

Two other notebooks were also pinned to `numpy<2` in #149's locks, but for unrelated reasons — they don't use any removed numpy APIs:

- `000559/.../reproduce_figure_S1.ipynb` — pinned because of `cellpose<4` (cellpose 4.x dropped the old `Cellpose` class the notebook uses). The numpy<2 is a transitive consequence of cellpose's deps, not a notebook-content issue.
- `000582/Sargolini2006/000582_Sargolini2006_demo.ipynb` — pinned via `pynapple>=0.6` transitive deps. Notebook code is numpy-2.x clean.

Those two would need different fixes (cellpose modernization / pynapple version bump) and are out of scope here.

The diff also includes nbformat-added cell `id` fields on a few previously-id-less cells — that's an automatic normalization on save, not a content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)