### PR TITLE
CI: improve manual-dispatch UX for the all-notebooks sweep

### DIFF
--- a/.github/workflows/test-all-notebooks-weekly.yml
+++ b/.github/workflows/test-all-notebooks-weekly.yml
@@ -1,4 +1,4 @@
-name: Test all notebooks (weekly)
+name: Test all notebooks (weekly + on-demand)
 
 on:
   schedule:
@@ -7,9 +7,21 @@ on:
   workflow_dispatch:
     inputs:
       filter:
-        description: 'Optional substring filter on notebook paths (regex)'
+        description: 'Regex on notebook paths (leave blank for all). Example: tutorials/.*'
         required: false
         default: ''
+      single_notebook:
+        description: 'Run a single notebook (full path). Overrides filter if set.'
+        required: false
+        default: ''
+      file_issue:
+        description: 'File/update the weekly-notebook-sweep tracking issue on failure'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 permissions:
   contents: read
@@ -32,15 +44,21 @@ jobs:
         id: list
         run: |
           set -euo pipefail
-          all=$(python .github/scripts/list_notebooks.py)
+          single='${{ github.event.inputs.single_notebook }}'
           filter='${{ github.event.inputs.filter }}'
-          if [ -n "$filter" ]; then
-            all=$(echo "$all" | python -c "
+          if [ -n "$single" ]; then
+            all=$(python -c "import json; print(json.dumps(['$single']))")
+            echo "Manual single-notebook run: $single"
+          else
+            all=$(python .github/scripts/list_notebooks.py)
+            if [ -n "$filter" ]; then
+              all=$(echo "$all" | python -c "
           import json, re, sys
           pat = re.compile(r'''$filter''')
           nbs = json.load(sys.stdin)
           print(json.dumps([n for n in nbs if pat.search(n)]))
           ")
+            fi
           fi
           echo "notebooks=$all" >> "$GITHUB_OUTPUT"
           count=$(echo "$all" | python -c "import json,sys;print(len(json.load(sys.stdin)))")
@@ -161,7 +179,7 @@ jobs:
           EOF
 
       - name: File or update tracking issue if any failures
-        if: steps.report.outputs.failed_count != '0'
+        if: steps.report.outputs.failed_count != '0' && github.event.inputs.file_issue != 'false'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
The all-notebooks sweep workflow already had a `workflow_dispatch` trigger (added in PR #153), but the only input was a regex filter — awkward for the common ad-hoc use cases. Three improvements:

## Changes

1. **Renamed** to *Test all notebooks (weekly + on-demand)* so it's obvious from the Actions page that manual dispatch is supported.

2. **Added `single_notebook` input** — paste one notebook path to test just that one, no regex needed. Overrides the filter if set. Useful for: "I just changed Sargolini, run only that against the full sweep environment."

3. **Added `file_issue` toggle** (true/false dropdown, default true).
   - Scheduled weekly runs keep filing/updating the tracking issue as before.
   - Ad-hoc manual runs can be flipped to `false` to avoid noisy issue comments while iterating on a change.

## How to use after this lands

**Web UI:**
```
Actions tab → "Test all notebooks (weekly + on-demand)"
  → "Run workflow" button (top right) → fill in inputs → Run.
```

**CLI:**
```bash
gh workflow run 'Test all notebooks (weekly + on-demand)' \
  -f single_notebook='000582/Sargolini2006/000582_Sargolini2006_demo.ipynb' \
  -f file_issue=false
```

## Note: this was already partly possible

The `workflow_dispatch` trigger has existed since PR #153 merged — the "Run workflow" button has been on the Actions page since then. This PR just makes the inputs richer and the workflow name clearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)