### PR TITLE
Fix curl missing --create-dirs for helper files in subdirectories

### DIFF
--- a/000402/MICrONS/coregistration/microns_nwb_coreg_notebook.ipynb
+++ b/000402/MICrONS/coregistration/microns_nwb_coreg_notebook.ipynb
@@ -160,8 +160,8 @@
     "    \"zarr-checksum==0.4.7\"\n",
     "\n",
     "!curl -sL -o ng_utils.py https://raw.githubusercontent.com/dandi/example-notebooks/master/000402/MICrONS/coregistration/ng_utils.py\n",
-    "!curl -sL -o ng_visualization/functional_base_state.json https://raw.githubusercontent.com/dandi/example-notebooks/master/000402/MICrONS/coregistration/ng_visualization/functional_base_state.json\n",
-    "!curl -sL -o ng_visualization/structural_base_state.json https://raw.githubusercontent.com/dandi/example-notebooks/master/000402/MICrONS/coregistration/ng_visualization/structural_base_state.json\n",
+    "!curl --create-dirs -sL -o ng_visualization/functional_base_state.json https://raw.githubusercontent.com/dandi/example-notebooks/master/000402/MICrONS/coregistration/ng_visualization/functional_base_state.json\n",
+    "!curl --create-dirs -sL -o ng_visualization/structural_base_state.json https://raw.githubusercontent.com/dandi/example-notebooks/master/000402/MICrONS/coregistration/ng_visualization/structural_base_state.json\n",
     "!curl -sL -o ScanUnit.pkl https://raw.githubusercontent.com/dandi/example-notebooks/master/000402/MICrONS/coregistration/ScanUnit.pkl"
    ]
   },
@@ -240,7 +240,7 @@
     "from tqdm import tqdm\n",
     "import pandas as pd\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {

--- a/000458/FlatironInstitute/001_summarize_contents.ipynb
+++ b/000458/FlatironInstitute/001_summarize_contents.ipynb
@@ -129,7 +129,7 @@
     "    \"zarr==2.18.7\" \\\n",
     "    \"zarr-checksum==0.4.7\"\n",
     "\n",
-    "!curl -sL -o helpers/stream_nwbfile.py https://raw.githubusercontent.com/dandi/example-notebooks/master/000458/FlatironInstitute/helpers/stream_nwbfile.py"
+    "!curl --create-dirs -sL -o helpers/stream_nwbfile.py https://raw.githubusercontent.com/dandi/example-notebooks/master/000458/FlatironInstitute/helpers/stream_nwbfile.py"
    ]
   },
   {

--- a/001075/001075_paper_figure_1d.ipynb
+++ b/001075/001075_paper_figure_1d.ipynb
@@ -136,9 +136,9 @@
     "    \"zarr==2.18.7\" \\\n",
     "    \"zarr-checksum==0.4.7\"\n",
     "\n",
-    "!curl -sL -o utils_001075/__init__.py https://raw.githubusercontent.com/dandi/example-notebooks/master/001075/utils_001075/__init__.py\n",
-    "!curl -sL -o utils_001075/_stream_nwbfile.py https://raw.githubusercontent.com/dandi/example-notebooks/master/001075/utils_001075/_stream_nwbfile.py\n",
-    "!curl -sL -o utils_001075/_waterfall.py https://raw.githubusercontent.com/dandi/example-notebooks/master/001075/utils_001075/_waterfall.py"
+    "!curl --create-dirs -sL -o utils_001075/__init__.py https://raw.githubusercontent.com/dandi/example-notebooks/master/001075/utils_001075/__init__.py\n",
+    "!curl --create-dirs -sL -o utils_001075/_stream_nwbfile.py https://raw.githubusercontent.com/dandi/example-notebooks/master/001075/utils_001075/_stream_nwbfile.py\n",
+    "!curl --create-dirs -sL -o utils_001075/_waterfall.py https://raw.githubusercontent.com/dandi/example-notebooks/master/001075/utils_001075/_waterfall.py"
    ]
   },
   {


### PR DESCRIPTION
## The bug

User report from a Colab run of `001_summarize_contents.ipynb`:

```
ModuleNotFoundError: No module named 'helpers'
```

Three notebooks fetch a helper file via `curl` into a subdirectory that doesn't exist yet on a fresh Colab runtime:

| Notebook | Target subdir |
|---|---|
| `001075/001075_paper_figure_1d.ipynb` | `utils_001075/` |
| `000458/.../001_summarize_contents.ipynb` | `helpers/` |
| `000402/.../microns_nwb_coreg_notebook.ipynb` | `ng_visualization/` |

`curl -o subdir/file.py URL` without `--create-dirs` fails silently when `subdir/` doesn't exist — and with `-s` (silent) you don't even see the error. The install cell appears to succeed; then the next cell hits the `ModuleNotFoundError`.

## Fix

One-flag change per curl: insert `--create-dirs` right after `!curl`. That makes curl create the parent directory if it doesn't exist (equivalent to a `mkdir -p` first).

Curl commands writing to the current directory (e.g. `ScanUnit.pkl`, `ng_utils.py`) are untouched — they don't need the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)