### PR TITLE
reproduce_figure1d: bump numpy 1.26 → 2.0 (np.NaN fix is in)

### DIFF
--- a/000559/dattalab/markowitz_gillis_nature_2023/reproduce_figure1d.ipynb
+++ b/000559/dattalab/markowitz_gillis_nature_2023/reproduce_figure1d.ipynb
@@ -93,7 +93,7 @@
     "    \"natsort==8.4.0\" \\\n",
     "    \"neuroconv==0.7.1\" \\\n",
     "    \"numcodecs==0.15.1\" \\\n",
-    "    \"numpy==1.26.4\" \\\n",
+    "    \"numpy==2.0.2\" \\\n",
     "    \"nwbinspector==0.6.3\" \\\n",
     "    \"packaging==26.1\" \\\n",
     "    \"pandas==2.2.2\" \\\n",


### PR DESCRIPTION
PR #159's regen pinned this notebook to `numpy==1.26.4` because the PR-141-era input deps included `numpy>=1.26,<2`. That `<2` cap was there because the notebook code used `np.NaN` (removed in numpy 2.0).

**PR #156 already replaced `np.NaN` with `np.nan`** — the notebook code has been numpy-2.x clean for a while. The `<2` cap was just never refreshed in the input deps.

## Fix

One-line: re-resolved the lock with `numpy>=1.26` (no upper cap) against the Colab constraints set. Every other pin was already at Colab versions from #159, so the only line that changed is numpy:

```
numpy  1.26.4 → 2.0.2
```

Now matches Colab's preinstalled `numpy==2.0.2`, so the install cell is a no-op for numpy on a fresh Colab runtime — **no kernel restart needed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)