### PR TITLE
Index page: wider content area + DANDI favicon

### DIFF
--- a/.github/templates/index.html
+++ b/.github/templates/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DANDI Example Notebooks</title>
+    <link rel="icon" href="https://dandiarchive.org/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -41,7 +42,7 @@
         }
 
         .container {
-            max-width: 1160px;
+            max-width: 1480px;
             margin: 0 auto;
             padding: 0 32px;
         }


### PR DESCRIPTION
Two small aesthetic improvements to the GitHub Pages index:

## 1. Content max-width 1160 → 1480 px

The layout is `340px sticky TOC + 64px gap + main column`, so the main column was only `1160 - 32*2 - 340 - 64 = 696px` wide. Notebook paths often run 60+ characters (`000559/dattalab/markowitz_gillis_nature_2023/reproduce_figure_S1.ipynb`, etc.) and were wrapping awkwardly. New main column is ~980 px and dense rows fit on one line.

```diff
- max-width: 1160px;
+ max-width: 1480px;
```

## 2. DANDI favicon

```diff
+ <link rel="icon" href="https://dandiarchive.org/favicon.ico">
```

The browser tab no longer shows the generic blank-page icon. Sourced directly from `dandiarchive.org/favicon.ico` — so if DANDI rebrands the icon, ours updates automatically with no extra change needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)