### PR TITLE
codespell: ignore 'aci' (variable name in IBL-Widefield notebook)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -5,4 +5,5 @@ ignore-regex = "image/png": ".*|^ *".*data:\S+;base64.*
 # nd - people just like it
 
 # makin - surname (Joseph G. Makin, cited in 000129/MathisLab CEBRA notebook)
-ignore-words-list = nd,trough,mater,mebrains,makin
+# aci - variable name for `anatomical_coordinates_image` in 001712/IBL-Widefield
+ignore-words-list = nd,trough,mater,mebrains,makin,aci


### PR DESCRIPTION
Fixes the [Codespell run on PR #142](https://github.com/dandi/example-notebooks/actions/runs/25836921722/job/75913910465).

## What was failing

Codespell flagged ~50 occurrences of `aci` in `001712/IBL-Widefield/public_demo/anatomical_localization_widefield.ipynb` as typos for `acpi`. The string is actually a **local variable shorthand** for the NWB field `anatomical_coordinates_image`:

```python
aci = localization.anatomical_coordinates_images["AnatomicalCoordinatesImageCCFv3"]
space        = aci.space
x_coords     = aci.x[:]
y_coords     = aci.y[:]
region_names = np.asarray(aci.brain_region[:])
```

## Fix

Added `aci` to `.codespellrc`'s `ignore-words-list` with an inline comment naming the variable + the notebook it lives in. Same pattern as PR #154's `makin` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)