### PR TITLE
Set GitHub Pages custom domain to `notebooks.dandiarchive.org`

### DIFF
--- a/.github/workflows/index_workflow.yml
+++ b/.github/workflows/index_workflow.yml
@@ -29,3 +29,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./output
         keep_files: true
+        cname: notebooks.dandiarchive.org


### PR DESCRIPTION
- Paired with dandi/dandi-infrastructure#279

cc @satra