### PR TITLE
TurnerLab 001636: pin numpy to 2.0.2 (match Colab runtime)

### DIFF
--- a/001636/TurnerLab/motor_cortex/antidromic_detection_tutorial.ipynb
+++ b/001636/TurnerLab/motor_cortex/antidromic_detection_tutorial.ipynb
@@ -148,7 +148,7 @@
     "    \"notebook-shim==0.2.4\" \\\n",
     "    \"numba==0.65.1\" \\\n",
     "    \"numcodecs==0.15.1\" \\\n",
-    "    \"numpy==2.2.6\" \\\n",
+    "    \"numpy==2.0.2\" \\\n",
     "    \"nwbinspector==0.7.1\" \\\n",
     "    \"opt-einsum==3.4.0\" \\\n",
     "    \"optax==0.2.8\" \\\n",

--- a/001636/TurnerLab/motor_cortex/environment.yml
+++ b/001636/TurnerLab/motor_cortex/environment.yml
@@ -14,7 +14,7 @@ dependencies:
       - matplotlib==3.10.8
       - nemos==0.2.6
       - optimistix==0.0.11
-      - numpy==2.2.6
+      - numpy==2.0.2
       - pandas==2.3.3
       - pynapple==0.10.3
       - pynwb==3.1.3

--- a/001636/TurnerLab/motor_cortex/turner_m1_glm.ipynb
+++ b/001636/TurnerLab/motor_cortex/turner_m1_glm.ipynb
@@ -148,7 +148,7 @@
     "    \"notebook-shim==0.2.4\" \\\n",
     "    \"numba==0.65.1\" \\\n",
     "    \"numcodecs==0.15.1\" \\\n",
-    "    \"numpy==2.2.6\" \\\n",
+    "    \"numpy==2.0.2\" \\\n",
     "    \"nwbinspector==0.7.1\" \\\n",
     "    \"opt-einsum==3.4.0\" \\\n",
     "    \"optax==0.2.8\" \\\n",

--- a/001636/TurnerLab/motor_cortex/turner_m1_peth.ipynb
+++ b/001636/TurnerLab/motor_cortex/turner_m1_peth.ipynb
@@ -148,7 +148,7 @@
     "    \"notebook-shim==0.2.4\" \\\n",
     "    \"numba==0.65.1\" \\\n",
     "    \"numcodecs==0.15.1\" \\\n",
-    "    \"numpy==2.2.6\" \\\n",
+    "    \"numpy==2.0.2\" \\\n",
     "    \"nwbinspector==0.7.1\" \\\n",
     "    \"opt-einsum==3.4.0\" \\\n",
     "    \"optax==0.2.8\" \\\n",

--- a/001636/TurnerLab/motor_cortex/turner_m1_usage.ipynb
+++ b/001636/TurnerLab/motor_cortex/turner_m1_usage.ipynb
@@ -148,7 +148,7 @@
     "    \"notebook-shim==0.2.4\" \\\n",
     "    \"numba==0.65.1\" \\\n",
     "    \"numcodecs==0.15.1\" \\\n",
-    "    \"numpy==2.2.6\" \\\n",
+    "    \"numpy==2.0.2\" \\\n",
     "    \"nwbinspector==0.7.1\" \\\n",
     "    \"opt-einsum==3.4.0\" \\\n",
     "    \"optax==0.2.8\" \\\n",


### PR DESCRIPTION
Colab 2026.04 ships **numpy 2.0.2** on Python 3.12. The TurnerLab 001636 notebooks pinned `numpy==2.2.6`, which forces an in-kernel numpy upgrade (and a runtime restart) when run on Colab.

Nothing in the dependency graph requires `>2.0` — `numba==0.65.1` (the tightest constraint) allows `numpy>=1.22,<2.5` — so 2.0.2 resolves cleanly with the full jax / numba / nemos / pynapple GLM stack unchanged. The 2.2.6 value was a free choice in `environment.yml`, not a requirement.

### Change
Edits the **numpy pin only** in each install cell and `environment.yml`; the rest of the Colab-matched lock (incl. the `ipython==7.34.0` jupyter stack) is untouched.

### Verification
All four notebooks executed end-to-end via `.github/scripts/run_notebook.py` with numpy 2.0.2 → `ok: true`:

| Notebook | Result |
|---|---|
| `turner_m1_glm` (numba + jax GLM fit) | ✅ 92s |
| `turner_m1_peth` | ✅ 25s |
| `turner_m1_usage` | ✅ 34s |
| `antidromic_detection_tutorial` | ✅ 32s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)